### PR TITLE
Fix `rustup target add` command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ rustup toolchain install nightly --component rust-src
 Run the following command in a terminal window:
 
 ```shell
-rustup target add riscv32imc -unknown -none -elf
+rustup target add riscv32imc-unknown-none-elf
 ```
 
 #### d) **Install `espflash`**: 


### PR DESCRIPTION
It gave me the following error:
```
> rustup target add riscv32imc -unknown -none -elf
error: unexpected argument '-u' found

  tip: to pass '-u' as a value, use '-- -u'

Usage: rustup[EXE] target add [OPTIONS] <TARGET>...

For more information, try '--help'.
```
